### PR TITLE
Added support for lilting provided files by paths

### DIFF
--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -4,47 +4,78 @@ import PackagePlugin
 @main
 struct SwiftLintCommandPlugin: CommandPlugin {
     func performCommand(context: PluginContext, arguments: [String]) throws {
+        Diagnostics.remark("Command plugin arguments: \(arguments)")
+
         guard !arguments.contains("--cache-path") else {
             Diagnostics.error("Caching is managed by the plugin and so setting `--cache-path` is not allowed")
             return
         }
         var argExtractor = ArgumentExtractor(arguments)
         let targetNames = argExtractor.extractOption(named: "target")
-        let targets = targetNames.isEmpty
-            ? context.package.targets
-            : try context.package.targets(named: targetNames)
-        let tool = try context.tool(named: "swiftlint")
-        for target in targets {
-            guard let target = target.sourceModule else {
-                Diagnostics.warning("Target '\(target.name)' is not a source module; skipping it")
-                continue
-            }
+        let remainingArguments = argExtractor.remainingArguments
 
-            let process = Process()
-            process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
-            process.executableURL = URL(fileURLWithPath: tool.path.string)
-            process.arguments = arguments
-            if !arguments.contains("analyze") {
-                // The analyze command does not support the `--cache-path` argument.
-                process.arguments! += ["--cache-path", "\(context.pluginWorkDirectory.string)"]
-            }
-            process.arguments! += [target.directory.string]
+        Diagnostics.remark("Remaining arguments: \(remainingArguments)")
 
-            try process.run()
-            process.waitUntilExit()
-            switch process.terminationReason {
-            case .exit:
-                Diagnostics.remark("Finished running in module '\(target.name)'")
-            case .uncaughtSignal:
-                Diagnostics.error("Got uncaught signal while running in module '\(target.name)'")
-            @unknown default:
-                Diagnostics.error("Stopped running in module '\(target.name) due to unexpected termination reason")
+        let targets: [Target]? = try {
+            if !targetNames.isEmpty {
+                return try context.package.targets(named: targetNames)
             }
-            if process.terminationStatus != EXIT_SUCCESS {
-                Diagnostics.warning(
-                    "Command found violations or unsuccessfully stopped running in module '\(target.name)'"
-                )
+            if let pathArgument = remainingArguments.last, FileManager.default.fileExists(atPath: pathArgument) {
+                Diagnostics.remark("No targets provided, paths from remaining arguments will be used")
+                return nil
             }
+            return context.package.targets
+        }()
+
+        var arguments = remainingArguments
+        if !arguments.contains("analyze") {
+            // The analyze command does not support the `--cache-path` argument.
+            arguments.insert(contentsOf: ["--cache-path", "\(context.pluginWorkDirectory.string)"], at: 0)
+        }
+
+        if let targets {
+            Diagnostics.remark("Will act on targets: \(targets)")
+            for target in targets {
+                guard let target = target.sourceModule else {
+                    Diagnostics.warning("Target '\(target.name)' is not a source module; skipping it")
+                    continue
+                }
+                let arguments = arguments + [target.directory.string]
+                try runProcess(title: "module '\(target.name)'", context: context, arguments: arguments)
+            }
+        } else {
+            try runProcess(title: "listed files", context: context, arguments: arguments)
         }
     }
+
+    private func runProcess(title: String, context: PluginContext, arguments: [String]) throws {
+        let tool = try context.tool(named: "swiftlint")
+        let process = Process()
+        process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
+        process.executableURL = URL(fileURLWithPath: tool.path.string)
+        process.arguments = arguments
+
+        Diagnostics.remark("Run arguments: \(process.arguments!)")
+
+        try process.run()
+        process.waitUntilExit()
+        switch process.terminationReason {
+        case .exit:
+            Diagnostics.remark("Finished running for \(title)")
+        case .uncaughtSignal:
+            Diagnostics.error("Got uncaught signal while running for \(title)")
+        @unknown default:
+            Diagnostics.error("Stopped running for \(title) due to unexpected termination reason")
+        }
+        if process.terminationStatus != EXIT_SUCCESS {
+            Diagnostics.warning(
+                "Command found violations or unsuccessfully stopped running for \(title)"
+            )
+            throw Error.unsuccessfulLinting
+        }
+    }
+}
+
+private enum Error: LocalizedError {
+    case unsuccessfulLinting
 }


### PR DESCRIPTION
- Fixed "Unknown option '--target'". Option was passed to swiftlint tool even after extracting that option to determine targets' paths.
  - swiftlint tool doesn't support '--target' option, only command plugin does.
  - '--target' is passed by Xcode when you use GUI to run plugin command 
  (see https://github.com/realm/SwiftLint/issues/5603)
- Backwards compatibility
  - pass arguments without defining targets to run linting on all targets with passed arguments.
  - pass arguments and '--target' option to lint provided targets with provided arguments.
- New: pass arguments and paths without '--target' option to run linting only on these paths with passed arguments.