### PR TITLE
Use `Diagnostics.error` when `terminationStatus` isn't `EXIT_SUCCESS`

### DIFF
--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -32,6 +32,7 @@ struct SwiftLintCommandPlugin: CommandPlugin {
 
             try process.run()
             process.waitUntilExit()
+
             switch process.terminationReason {
             case .exit:
                 Diagnostics.remark("Finished running in module '\(target.name)'")
@@ -40,9 +41,10 @@ struct SwiftLintCommandPlugin: CommandPlugin {
             @unknown default:
                 Diagnostics.error("Stopped running in module '\(target.name) due to unexpected termination reason")
             }
+
             if process.terminationStatus != EXIT_SUCCESS {
-                Diagnostics.warning(
-                    "Command found violations or unsuccessfully stopped running in module '\(target.name)'"
+                Diagnostics.error(
+                    "Command found violations or unsuccessfully stopped running in module '\(target.name)' / Exit code: '\(process.terminationStatus)'"
                 )
             }
         }


### PR DESCRIPTION
Previously, we were using `Diagnostics.warning` in `SwiftLintCommandPlugin` when `terminationStatus` wasn't `EXIT_SUCCESS`, which caused the command to always return a `0` code even if it failed. Using `Diagnostics.error` it will return `1` and will allow us to properly handle the error.

## Before

```sh
$ swift package plugin swiftlint --quiet --strict
$ [...]
$ warning: Command found violations or unsuccessfully stopped running in module 'Example'
$ echo $?
$ 0
```

## After

```sh
$ swift package plugin swiftlint --quiet --strict
$ [...]
$ error: Command found violations or unsuccessfully stopped running in module 'Example' / Exit code: '2'
$ echo $?
$ 1
```