### PR TITLE
Publish SwiftLintBinary as an executable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,21 +63,18 @@ jobs:
       - name: Check that all commands pass
         run: |
           swift package plugin --allow-writing-to-package-directory swiftlint | grep -q "Force Cast Violation"
-      - name: Verify that SwiftLintBinary executable is available (MacOS 14 only)
-        if: ${{ matrix.os == 'macos-14' }}
-        run: swift package dump-package | grep -q SwiftLintBinary
-      - name: Verify that SwiftLintBinary executable is available (non-MacOS 14)
+      - name: Verify that SwiftLintBinary executable is available (MacOS 15+)
         if: ${{ matrix.os != 'macos-14' }}
         run: swift package show-executables | grep -q SwiftLintBinary
-      - name: Verify that SwiftLintBinary executes and all commands pass (macOS)
+      - name: Verify that SwiftLintBinary executes (macOS)
         if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint | grep -q "Force Cast Violation"
-      - name: Verify that SwiftLintBinary executes and all commands pass (Ubuntu amd64)
+      - name: Verify that SwiftLintBinary executes (Ubuntu amd64)
         if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/linux/amd64/swiftlint | grep -q "Force Cast Violation"
-      - name: Verify that SwiftLintBinary executes and all commands pass (Ubuntu arm64)
+      - name: Verify that SwiftLintBinary executes (Ubuntu arm64)
         if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: |
           ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/linux/arm64/swiftlint | grep -q "Force Cast Violation"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,21 @@ jobs:
       - name: Verify that SwiftLintBinary executable is available (MacOS 14 only)
         if: ${{ matrix.os == 'macos-14' }}
         run: swift package dump-package | grep -q SwiftLintBinary
-      - name: Verify that SwiftLintBinary executable is available (MacOS 15+)
+      - name: Verify that SwiftLintBinary executable is available (non-MacOS 14)
         if: ${{ matrix.os != 'macos-14' }}
         run: swift package show-executables | grep -q SwiftLintBinary
-      - name: Verify that SwiftLintBinary executes and all commands pass
+      - name: Verify that SwiftLintBinary executes and all commands pass (macOS)
+        if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint | grep -q "Force Cast Violation"
+      - name: Verify that SwiftLintBinary executes and all commands pass (Ubuntu amd64)
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        run: |
+          ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/linux/amd64/swiftlint | grep -q "Force Cast Violation"
+      - name: Verify that SwiftLintBinary executes and all commands pass (Ubuntu arm64)
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        run: |
+          ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/linux/arm64/swiftlint | grep -q "Force Cast Violation"
 
   xcode:
     name: Xcode ${{ matrix.xcode_version }}, ${{ matrix.display_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,11 @@ jobs:
       - name: Check that all commands pass
         run: |
           swift package plugin --allow-writing-to-package-directory swiftlint | grep -q "Force Cast Violation"
-      - name: Verify that SwiftLintBinary executable is available
+      - name: Verify that SwiftLintBinary executable is available (MacOS 14 only)
+        if: ${{ matrix.os == 'macos-14' }}
+        run: swift package dump-package | grep -q SwiftLintBinary
+      - name: Verify that SwiftLintBinary executable is available (MacOS 15+)
+        if: ${{ matrix.os != 'macos-14' }}
         run: swift package show-executables | grep -q SwiftLintBinary
       - name: Verify that SwiftLintBinary executes and all commands pass
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Check that all commands pass
         run: |
           swift package plugin --allow-writing-to-package-directory swiftlint | grep -q "Force Cast Violation"
+      - name: Verify that SwiftLintBinary executable is available
+        run: swift package show-executables | grep -q SwiftLintBinary
 
   xcode:
     name: Xcode ${{ matrix.xcode_version }}, ${{ matrix.display_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
           swift package plugin --allow-writing-to-package-directory swiftlint | grep -q "Force Cast Violation"
       - name: Verify that SwiftLintBinary executable is available
         run: swift package show-executables | grep -q SwiftLintBinary
+      - name: Verify that SwiftLintBinary executes and all commands pass
+        run: |
+          ./.build/artifacts/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint | grep -q "Force Cast Violation"
 
   xcode:
     name: Xcode ${{ matrix.xcode_version }}, ${{ matrix.display_name }}

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .macOS(.v12)
     ],
     products: [
-        .executable(name: "SwiftLintBinary", targets: ["SwiftLintBinary"])
+        .executable(name: "SwiftLintBinary", targets: ["SwiftLintBinary"]),
         .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"]),
         .plugin(name: "SwiftLintCommandPlugin", targets: ["SwiftLintCommandPlugin"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .macOS(.v12)
     ],
     products: [
+        .executable(name: "SwiftLintBinary", targets: ["SwiftLintBinary"])
         .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"]),
         .plugin(name: "SwiftLintCommandPlugin", targets: ["SwiftLintCommandPlugin"])
     ],


### PR DESCRIPTION
This enables any consumer to rely on the SwiftLint binary to create custom plugins and variations according to the specific codebase and project needs